### PR TITLE
Small doc correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The iOS SDK can be found here: https://github.com/segmentio/analytics-ios
 var RNSegmentIOAnalytics = require('react-native-segment-io-analytics');
 
 var segmentIOWriteKey = "SEGMENT_IO_WRITE_KEY"
-var flushEverySecondsCount = 1
-RNSegmentIOAnalytics.setup(segmentIOWriteKey, flushEverySecondsCount);
+var eventQueueSize = 1
+RNSegmentIOAnalytics.setup(segmentIOWriteKey, eventQueueSize);
 RNSegmentIOAnalytics.identifyUser("testing", {"name":"test name"});
 RNSegmentIOAnalytics.track("test track", {"name":"test track with name"});
 RNSegmentIOAnalytics.screen("test screen", {"screenType":"SCREEN NAME"});


### PR DESCRIPTION
The docs in the readme call the `flushAt` variable `flushEverySecondsCount`, but according to the [iOS Configuration Docs](https://segment.com/docs/libraries/ios/#configuration), it's a queue size, not a rate. Not a big deal, but a small clarification.